### PR TITLE
strike a balance between env variable and hard coded

### DIFF
--- a/model/seasons.js
+++ b/model/seasons.js
@@ -46,7 +46,7 @@ function loadSeason(key) {
   return season;
 }
 
-var CURRENT = 'season-13';
+var CURRENT = process.env.CURRENT_SEASON || 'season-13';
 
 var _map = {
   // Not sure why we would need to load other seasons like this.


### PR DESCRIPTION
Got it up and running after spending a bunch of time consolidating env variables, only to realize I was on the original and not your fork. This code makes it so the season isn't hard coded but has a default value if `CURRENT_SEASON` isn't provided. 