### PR TITLE
Display Elapsed Time on the picking and responding pages. 

### DIFF
--- a/model/matches.js
+++ b/model/matches.js
@@ -315,7 +315,7 @@ function Match(params) {
   this.round = 1;
   this.create_at = Date.now();
   this.date = params.date || getDate();
-  this.state = params.state || CONST.PREGAME;
+  this.setState(params.state || CONST.PREGAME);
   var vk = params.venue ? params.venue.key ? params.venue.key : params.venue : null;
   var venue = vk ? venues.get(vk) : null;
   if(!venue) {
@@ -556,7 +556,7 @@ Match.prototype = {
 
     if(team.confirmed && team.ready) {
       //It's time for the match to move on to playing!
-      this.state = CONST.PICKING;
+      this.setState(CONST.PICKING);
       this.round = 1;
     }
     this.save();
@@ -734,7 +734,7 @@ Match.prototype = {
             this.step++;
           }
           else {
-            this.state = CONST.PLAYING;
+            this.setState(CONST.PLAYING);
           }
         }
       }
@@ -760,11 +760,11 @@ Match.prototype = {
         console.log("state:",this.state,"picksReady:",picksReady);
 
         if(this.state == CONST.PICKING) {
-          if(picksReady) this.state = CONST.RESPONDING;
+          if(picksReady) this.setState(CONST.RESPONDING);
         }
         else if(this.state == CONST.RESPONDING) {
           if(picksReady) {
-            this.state = CONST.PLAYING;
+            this.setState(CONST.PLAYING);
           }
         }
         // ++++++++++++ End of regular round logic +++++++++++++
@@ -988,7 +988,7 @@ Match.prototype = {
     if(roundDone(round)) {
       //Check to see if the match is done?
       // if(r == this.round) {
-      //   this.state = CONST.REVIEWING;
+      //   this.setState(CONST.REVIEWING);
       // }
     }
     else {
@@ -1059,10 +1059,10 @@ Match.prototype = {
 
       if(this.round < 4) {
         this.round++;
-        this.state = CONST.PICKING;
+        this.setState(CONST.PICKING);
       }
       else {
-        this.state = CONST.COMPLETE;
+        this.setState(CONST.COMPLETE);
       }
     };
     this.save();
@@ -1094,6 +1094,10 @@ Match.prototype = {
   save: function() {
     var json = JSON.stringify(this,null,2);
     fs.writeFileSync(`${stem}/matches/${this.key}.json`,json);
+  },
+  setState: function(s) {
+    this.state = s;
+    this.state_at = Date.now();
   }
 };
 

--- a/route/mnp.js
+++ b/route/mnp.js
@@ -779,6 +779,7 @@ function renderMatch(params) {
     doubles: (num == 4),
     shared: round.n == 5, //ROUND, using again.
     machines: JSON.stringify(venue.machines),
+    referenceTime: match.state_at,
     lineup: JSON.stringify(lineup),
     editable: editable,
     canAdd: ukey == CONST.ROOT,

--- a/static/timer.js
+++ b/static/timer.js
@@ -1,0 +1,24 @@
+/*
+   Used by template/picking.html and template/responding.html to implement a
+   timer on the picking and responding pages so that captains will know how
+   long they are taking to choose machines and players.
+*/
+var referenceTime = 0;
+
+function getElapsedTime() {
+   return formatSeconds(Date.now() - referenceTime);
+}
+
+function formatSeconds(s) {
+   return new Date(s).toISOString().substr(11, 8);
+}
+
+function renderElapsedTime(t) {
+   if (t !== undefined) {
+      referenceTime = t
+   }
+   $("span.elapsed").text(getElapsedTime());
+   setTimeout(function() {
+      renderElapsedTime()
+   }, 1000);
+}

--- a/template/picking.html
+++ b/template/picking.html
@@ -13,6 +13,8 @@
 {{/shared}}
 <!-- {{role}} -->
 <b>Picking: {{team_name}}</b>
+<br>
+<b>Timer: <span class="elapsed"></span></b><br>
 
 {{#editable}}
 <form action="/matches/{{key}}/picks" method="POST">
@@ -32,11 +34,15 @@
 </form>
 {{/editable}}
 
+<script src="/timer.js"></script>
+
 <script>
 var machines = {{&machines}};
 var games = {{&games}};
 var lineup = {{&lineup}};
 var labels = {{&labels}};
+
+renderElapsedTime({{&referenceTime}});
 
 function makeSelect(name, hint, options, selected) {
   var html = '<select name="' +name+ '" class="custom-select">'+

--- a/template/responding.html
+++ b/template/responding.html
@@ -5,6 +5,8 @@
 {{/errors}}
 <!-- {{role}} -->
 <b>Responding: {{team_name}}</b>
+<br>
+<b>Timer: <span class="elapsed"></span></b><br>
 
 {{#editable}}
 <form action="/matches/{{key}}/picks" method="POST">
@@ -24,11 +26,15 @@
 </form>
 {{/editable}}
 
+<script src="/timer.js"></script>
+
 <script>
 var machines = {{&machines}};
 var games = {{&games}};
 var lineup = {{&lineup}};
 var labels = {{&labels}};
+
+renderElapsedTime({{&referenceTime}});
 
 function makeSelect(name, hint, options, selected) {
   var html = '<select name="' +name+ '" class="custom-select">'+


### PR DESCRIPTION
The purpose of this is to nudge captains into taking less time to choose machines and players. With this change, we capture the time at which the match's state changes in a variable called state_at. This becomes the origin time (referenceTime) for computing elapsed time.

Tested on localhost using season 22 week 7. These same changes have been in use on https://northend.seattle.streetleaguepinball.com/ for two seasons.