### PR TITLE
Added /mymatch route and corresponding menu option "My Match". 

### DIFF
--- a/route/mnp.js
+++ b/route/mnp.js
@@ -514,6 +514,21 @@ router.post('/matches/:match_id/players/add',function(req,res) {
   });
 });
 
+// /mymatch takes the user directly to their most recent match.
+
+router.get('/mymatch', function(req,res) {
+  var ukey = req.user.key || 'ANON';
+  var match = matches.uget(ukey);
+
+  if (!match) { return res.redirect('/matches'); }
+
+  res.send(renderMatch({
+    match: match,
+    ukey: ukey,
+    round: match.round
+  }));
+});
+
 router.get('/matches/:match_id',function(req,res) {
   //TODO: matches.get should be async to account for mongo.
   var match = matches.get(req.params.match_id);

--- a/template/base.html
+++ b/template/base.html
@@ -51,6 +51,7 @@ http://webdesignerwall.com/tutorials/css-responsive-navigation-menu
       <a class="dropdown-item" href="/schedule">SCHEDULE</a>
       <a class="dropdown-item" href="/standings">STANDINGS</a>
       <a class="dropdown-item" href="/matches">MATCHES</a>
+      <a class="dropdown-item" href="/mymatch">MY MATCH</a>
       <a class="dropdown-item" href="/stats">STATS</a>
       <a class="dropdown-item" href="/venues">VENUES</a>
       <a class="dropdown-item" href="/machines">MACHINES</a>


### PR DESCRIPTION
If a user is logged in, the "My Match" menu option takes the user straight to their team's match via the /mymatch route; otherwise, it takes the user to /matches

Most of the new code is executed via a new path /mymatch and won't affect any of the other code.  The one existing function that I changed is loadMatch(key) which now calls buildUserToMatchMap(json) from inside a try / catch block. This should be safe even if it fails, since it is being called from inside a try / catch.

I tested this on my Macbook using "node https.js" (logged in as "John Garnett"). It successfully took me to the latest SWL match. After I added week 10 matches, /mymatch started taking me to the SWL week 10 match.