### PR TITLE
Improve UX for accessing authenticated routes

### DIFF
--- a/route/mnp.js
+++ b/route/mnp.js
@@ -524,6 +524,7 @@ router.post('/matches/:match_id/players/add',function(req,res) {
 // /mymatch takes the user directly to their most recent match.
 
 router.get('/mymatch', function(req,res) {
+  if (!req.user.key) { return res.redirect('/login?redirect_url=/mymatch'); }
   var ukey = req.user.key || 'ANON';
   var match = matches.uget(ukey);
 
@@ -539,6 +540,7 @@ router.get('/mymatch', function(req,res) {
 // /myteam takes the user directly to their most recent team from stats.
 
 router.get('/myteam', function(req,res) {
+  if (!req.user.key) { return res.redirect('/login?redirect_url=/myteam'); }
   const season = seasons.get();
   var ukey = req.user.key || 'ANON';
   var myTeam = '';


### PR DESCRIPTION
redirect to login if user is not authenticated and trying to access an authenticated route.  this was confusing me last monday because i got logged out and it wasn't clear that i was in that state.  being forced to see a login is the better experience.